### PR TITLE
WIP: Add async events

### DIFF
--- a/examples/test.c
+++ b/examples/test.c
@@ -59,6 +59,7 @@ static void stuff()
                 char str[64] = "Another Dynamically Allocated String";
                 act(str);
         }
+        SPDR_ASYNC_EVENT_END(spdr, "Main", "stuff", 42);
 }
 
 int main(int argc, char **argv)
@@ -79,8 +80,8 @@ int main(int argc, char **argv)
         printf(" 世界.\n");
         SPDR_END(spdr, "Main", "printf");
 
+        SPDR_ASYNC_EVENT_BEGIN1(spdr, "Main", "stuff", 42, SPDR_INT("value", 1));
         stuff();
-
         {
                 double a = 0.0;
                 SPDR_EVENT2(spdr, "Main", "Non Finites",

--- a/include/spdr/spdr-private.h
+++ b/include/spdr/spdr-private.h
@@ -12,6 +12,9 @@ enum SPDR_Event_Type {
         SPDR_END = 'E',
         SPDR_METADATA = 'M',
         SPDR_COUNTER = 'C',
+        SPDR_ASYNC_EVENT_BEGIN = 'S',
+        SPDR_ASYNC_EVENT_STEP = 'T',
+        SPDR_ASYNC_EVENT_END = 'F',
 };
 
 enum SPDR_Event_Arg_Type {

--- a/include/spdr/spdr.h
+++ b/include/spdr/spdr.h
@@ -187,6 +187,31 @@ void spdr_report(struct SPDR_Context *context,
 #define SPDR_COUNTER3(spdr, cat, name, arg0, arg1, arg2)                       \
         UU_SPDR_TRACE3(spdr, cat, name, SPDR_COUNTER, arg0, arg1, arg2)
 
+/* __ Async events __ */
+
+/**
+ * An async event
+ */
+#define SPDR_ASYNC_EVENT_BEGIN(spdr, cat, name, id) UU_SPDR_TRACE1(spdr, cat, name, SPDR_ASYNC_EVENT_BEGIN, SPDR_INT("id", id))
+
+/**
+ * An async event with one parameter
+ */
+#define SPDR_ASYNC_EVENT_BEGIN1(spdr, cat, name, id, arg0)               \
+        UU_SPDR_TRACE2(spdr, cat, name, SPDR_ASYNC_EVENT_BEGIN, SPDR_INT("id", id), arg0)
+
+/**
+ * An async event with two parameters
+ */
+#define SPDR_ASYNC_EVENT_BEGIN2(spdr, cat, name, id, arg0, arg1)         \
+        UU_SPDR_TRACE3(spdr, cat, name, SPDR_ASYNC_EVENT_BEGIN, SPDR_INT("id", id), arg0, arg1)
+
+/**
+ * Ends an async event
+ */
+#define SPDR_ASYNC_EVENT_END(spdr, cat, name, id)                         \
+        UU_SPDR_TRACE1(spdr, cat, name, SPDR_ASYNC_EVENT_END, SPDR_INT("id", id))
+
 /* __ Metadata __ */
 
 /**


### PR DESCRIPTION
- Async events (for concurrent event handling)
- Null context behaves like never enabled tracing
- One Definition Rule workaround
- More hygienic: we don't extern most functions anymore