### PR TITLE
Null context

### DIFF
--- a/examples/perf-test.c
+++ b/examples/perf-test.c
@@ -14,14 +14,14 @@
 
 static struct SPDR_Context *gbl_spdr;
 
-static void *std_allocator_alloc(struct Allocator *self, size_t size)
+static void *std_allocator_alloc(struct SPDR_Allocator *self, size_t size)
 {
         (void)self;
 
         return malloc(size);
 }
 
-static void std_allocator_free(struct Allocator *self, void *ptr)
+static void std_allocator_free(struct SPDR_Allocator *self, void *ptr)
 {
         (void)self;
 
@@ -33,7 +33,7 @@ struct ThreadContext {
         int offset;
         int n;
 
-        struct Clock *clock;
+        struct SPDR_Clock *clock;
         uint64_t ts0;
         uint64_t ts1;
 
@@ -88,9 +88,9 @@ extern int main(int argc, char **argv)
         enum { LOG_N = 256 * 1024 * 1024 };
         void *spdr_buffer = malloc(LOG_N);
         uint64_t single_threaded_ms = 0;
-        struct Clock *clock;
-        struct Allocator std_allocator = {std_allocator_alloc,
-                                          std_allocator_free};
+        struct SPDR_Clock *clock;
+        struct SPDR_Allocator std_allocator = {std_allocator_alloc,
+                                               std_allocator_free};
         clock_init(&clock, &std_allocator);
 
         spdr_init(&gbl_spdr, spdr_buffer, LOG_N);

--- a/src/allocator.c
+++ b/src/allocator.c
@@ -1,12 +1,12 @@
 #include "allocator_type.h"
 #include "allocator.h"
 
-void *allocator_alloc(struct Allocator *allocator, size_t size)
+void *allocator_alloc(struct SPDR_Allocator *allocator, size_t size)
 {
         return allocator->alloc(allocator, size);
 }
 
-void allocator_free(struct Allocator *allocator, void *ptr)
+void allocator_free(struct SPDR_Allocator *allocator, void *ptr)
 {
         allocator->free(allocator, ptr);
 }

--- a/src/allocator.c
+++ b/src/allocator.c
@@ -1,12 +1,13 @@
 #include "allocator_type.h"
 #include "allocator.h"
 
-void *allocator_alloc(struct SPDR_Allocator *allocator, size_t size)
+spdr_internal void *allocator_alloc(struct SPDR_Allocator *allocator,
+                                    size_t size)
 {
         return allocator->alloc(allocator, size);
 }
 
-void allocator_free(struct SPDR_Allocator *allocator, void *ptr)
+spdr_internal void allocator_free(struct SPDR_Allocator *allocator, void *ptr)
 {
         allocator->free(allocator, ptr);
 }

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -1,11 +1,14 @@
 #ifndef UU_ALLOCATOR_H
 #define UU_ALLOCATOR_H
 
+#include "inlines.h"
+
 #include <stddef.h> /* for size_t */
 
 struct SPDR_Allocator;
 
-extern void *allocator_alloc(struct SPDR_Allocator *allocator, size_t size);
-extern void allocator_free(struct SPDR_Allocator *allocator, void *ptr);
+spdr_internal void *allocator_alloc(struct SPDR_Allocator *allocator,
+                                    size_t size);
+spdr_internal void allocator_free(struct SPDR_Allocator *allocator, void *ptr);
 
 #endif

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -3,9 +3,9 @@
 
 #include <stddef.h> /* for size_t */
 
-struct Allocator;
+struct SPDR_Allocator;
 
-extern void *allocator_alloc(struct Allocator *allocator, size_t size);
-extern void allocator_free(struct Allocator *allocator, void *ptr);
+extern void *allocator_alloc(struct SPDR_Allocator *allocator, size_t size);
+extern void allocator_free(struct SPDR_Allocator *allocator, void *ptr);
 
 #endif

--- a/src/allocator_type.h
+++ b/src/allocator_type.h
@@ -3,9 +3,9 @@
 
 #include <string.h>
 
-struct Allocator {
-        void *(*alloc)(struct Allocator *self, size_t size);
-        void (*free)(struct Allocator *self, void *ptr);
+struct SPDR_Allocator {
+        void *(*alloc)(struct SPDR_Allocator *self, size_t size);
+        void (*free)(struct SPDR_Allocator *self, void *ptr);
 };
 
 #endif

--- a/src/chars.c
+++ b/src/chars.c
@@ -56,7 +56,7 @@ static uint32_t decode(uint32_t *state, uint32_t *codep, uint8_t byte)
         return *state;
 }
 
-void chars_catchar(struct Chars *chars, const char c)
+void chars_catchar(struct SPDR_Chars *chars, const char c)
 {
         if (chars->capacity - chars->len < 1) {
                 chars->error = 1;
@@ -67,7 +67,7 @@ void chars_catchar(struct Chars *chars, const char c)
         chars->len++;
 }
 
-void chars_catjsonstr(struct Chars *chars, const char *utf8)
+void chars_catjsonstr(struct SPDR_Chars *chars, const char *utf8)
 {
         const char *ch;
 

--- a/src/chars.h
+++ b/src/chars.h
@@ -1,6 +1,8 @@
 #ifndef CHARS_H
 #define CHARS_H
 
+#include "inlines.h"
+
 struct SPDR_Chars {
         int error;
         char *chars;
@@ -13,7 +15,8 @@ struct SPDR_Chars {
                 0, NULL, 0, 0                                                  \
         }
 
-extern void chars_catsprintf(struct SPDR_Chars *chars, const char *format, ...);
-extern void chars_catjsonstr(struct SPDR_Chars *chars, const char *utf8);
+spdr_internal void
+chars_catsprintf(struct SPDR_Chars *chars, const char *format, ...);
+spdr_internal void chars_catjsonstr(struct SPDR_Chars *chars, const char *utf8);
 
 #endif

--- a/src/chars.h
+++ b/src/chars.h
@@ -1,7 +1,7 @@
 #ifndef CHARS_H
 #define CHARS_H
 
-struct Chars {
+struct SPDR_Chars {
         int error;
         char *chars;
         int len;
@@ -13,7 +13,7 @@ struct Chars {
                 0, NULL, 0, 0                                                  \
         }
 
-extern void chars_catsprintf(struct Chars *chars, const char *format, ...);
-extern void chars_catjsonstr(struct Chars *chars, const char *utf8);
+extern void chars_catsprintf(struct SPDR_Chars *chars, const char *format, ...);
+extern void chars_catjsonstr(struct SPDR_Chars *chars, const char *utf8);
 
 #endif

--- a/src/chars_posix.c
+++ b/src/chars_posix.c
@@ -3,7 +3,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-extern void chars_catsprintf(struct Chars *chars, const char *format, ...)
+extern void chars_catsprintf(struct SPDR_Chars *chars, const char *format, ...)
 {
         if (chars->error) {
                 return;

--- a/src/chars_posix.c
+++ b/src/chars_posix.c
@@ -3,7 +3,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-extern void chars_catsprintf(struct SPDR_Chars *chars, const char *format, ...)
+spdr_internal void
+chars_catsprintf(struct SPDR_Chars *chars, const char *format, ...)
 {
         if (chars->error) {
                 return;

--- a/src/chars_windows.c
+++ b/src/chars_windows.c
@@ -3,7 +3,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-extern void chars_catsprintf(struct Chars *chars, const char *format, ...)
+extern void chars_catsprintf(struct SPDR_Chars *chars, const char *format, ...)
 {
         if (chars->error) {
                 return;

--- a/src/chars_windows.c
+++ b/src/chars_windows.c
@@ -3,7 +3,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-extern void chars_catsprintf(struct SPDR_Chars *chars, const char *format, ...)
+spdr_internal void
+chars_catsprintf(struct SPDR_Chars *chars, const char *format, ...)
 {
         if (chars->error) {
                 return;

--- a/src/clock.c
+++ b/src/clock.c
@@ -4,13 +4,13 @@
 
 #include "clock_type.h"
 
-extern int clock_init_base(struct Clock **clockp,
-                           struct Allocator *allocator,
+extern int clock_init_base(struct SPDR_Clock **clockp,
+                           struct SPDR_Allocator *allocator,
                            uint64_t numerator,
                            uint64_t denominator)
 {
-        struct Clock *clock = VOID_PTR_CAST(
-            struct Clock, allocator_alloc(allocator, sizeof *clock));
+        struct SPDR_Clock *clock = VOID_PTR_CAST(
+            struct SPDR_Clock, allocator_alloc(allocator, sizeof *clock));
         if (!clock) {
                 return -1;
         }
@@ -24,21 +24,21 @@ extern int clock_init_base(struct Clock **clockp,
         return 0;
 }
 
-extern void clock_deinit(struct Clock **clockp)
+extern void clock_deinit(struct SPDR_Clock **clockp)
 {
-        struct Clock *clock = *clockp;
+        struct SPDR_Clock *clock = *clockp;
         allocator_free(clock->allocator, clock);
         *clockp = 0;
 }
 
-extern uint64_t clock_ticks_to_microseconds(struct Clock const *clock,
+extern uint64_t clock_ticks_to_microseconds(struct SPDR_Clock const *clock,
                                             uint64_t ticks)
 {
         return clock->microseconds_per_tick[0] * ticks /
                clock->microseconds_per_tick[1];
 }
 
-extern uint64_t clock_microseconds(struct Clock const *clock)
+extern uint64_t clock_microseconds(struct SPDR_Clock const *clock)
 {
         return clock_ticks_to_microseconds(clock, clock_ticks(clock));
 }

--- a/src/clock.h
+++ b/src/clock.h
@@ -1,10 +1,16 @@
 #ifndef UU_CLOCK_H
 #define UU_CLOCK_H
 
+#include "inlines.h"
 #include "uu-stdint.h" /* uint64_t */
 
 struct SPDR_Clock;
 struct SPDR_Allocator;
+
+extern int clock_init_base(struct SPDR_Clock **clockp,
+                           struct SPDR_Allocator *allocator,
+                           uint64_t numerator,
+                           uint64_t denominator);
 
 extern int clock_init(struct SPDR_Clock **clock,
                       struct SPDR_Allocator *allocator);

--- a/src/clock.h
+++ b/src/clock.h
@@ -3,14 +3,15 @@
 
 #include "uu-stdint.h" /* uint64_t */
 
-struct Clock;
-struct Allocator;
+struct SPDR_Clock;
+struct SPDR_Allocator;
 
-extern int clock_init(struct Clock **clock, struct Allocator *allocator);
-extern void clock_deinit(struct Clock **clock);
-extern uint64_t clock_ticks(struct Clock const *clock);
-extern uint64_t clock_ticks_to_microseconds(struct Clock const *clock,
+extern int clock_init(struct SPDR_Clock **clock,
+                      struct SPDR_Allocator *allocator);
+extern void clock_deinit(struct SPDR_Clock **clock);
+extern uint64_t clock_ticks(struct SPDR_Clock const *clock);
+extern uint64_t clock_ticks_to_microseconds(struct SPDR_Clock const *clock,
                                             uint64_t ticks);
-extern uint64_t clock_microseconds(struct Clock const *clock);
+extern uint64_t clock_microseconds(struct SPDR_Clock const *clock);
 
 #endif

--- a/src/clock_osx.c
+++ b/src/clock_osx.c
@@ -5,7 +5,8 @@
 
 #include "clock_type.h"
 
-extern int clock_init(struct Clock **clockp, struct Allocator *allocator)
+extern int clock_init(struct SPDR_Clock **clockp,
+                      struct SPDR_Allocator *allocator)
 {
         mach_timebase_info_data_t info;
         if (mach_timebase_info(&info)) {
@@ -16,7 +17,7 @@ extern int clock_init(struct Clock **clockp, struct Allocator *allocator)
                                info.denom * 1000);
 }
 
-extern uint64_t clock_ticks(struct Clock const *const clock)
+extern uint64_t clock_ticks(struct SPDR_Clock const *const clock)
 {
         (void)clock;
 

--- a/src/clock_type.h
+++ b/src/clock_type.h
@@ -11,9 +11,4 @@ struct SPDR_Clock {
         uint64_t microseconds_per_tick[2];
 };
 
-extern int clock_init_base(struct SPDR_Clock **clockp,
-                           struct SPDR_Allocator *allocator,
-                           uint64_t numerator,
-                           uint64_t denominator);
-
 #endif

--- a/src/clock_type.h
+++ b/src/clock_type.h
@@ -1,18 +1,18 @@
 #ifndef UU_CLOCK_TYPE_H
 #define UU_CLOCK_TYPE_H
 
-struct Allocator;
+struct SPDR_Allocator;
 
-struct Clock {
-        struct Allocator *allocator;
+struct SPDR_Clock {
+        struct SPDR_Allocator *allocator;
         /**
          * numerator/denominator to convert ticks to microseconds
          */
         uint64_t microseconds_per_tick[2];
 };
 
-extern int clock_init_base(struct Clock **clockp,
-                           struct Allocator *allocator,
+extern int clock_init_base(struct SPDR_Clock **clockp,
+                           struct SPDR_Allocator *allocator,
                            uint64_t numerator,
                            uint64_t denominator);
 

--- a/src/clock_windows.c
+++ b/src/clock_windows.c
@@ -4,7 +4,7 @@
 
 #include "clock_type.h"
 
-extern int clock_init(struct Clock **clockp, struct Allocator *allocator)
+extern int clock_init(struct SPDR_Clock **clockp, struct SPDR_Allocator *allocator)
 {
         LARGE_INTEGER qpf;
         if (!QueryPerformanceFrequency(&qpf)) {
@@ -14,7 +14,7 @@ extern int clock_init(struct Clock **clockp, struct Allocator *allocator)
         return clock_init_base(clockp, allocator, 1000000, qpf.QuadPart);
 }
 
-extern uint64_t clock_ticks(struct Clock const *clock)
+extern uint64_t clock_ticks(struct SPDR_Clock const *clock)
 {
         LARGE_INTEGER pc;
         QueryPerformanceCounter(&pc);

--- a/src/float.h
+++ b/src/float.h
@@ -1,6 +1,6 @@
 #ifndef UU_FLOAT_H
 #define UU_FLOAT_H
 
-extern int float_isfinite(double value);
+spdr_internal int float_isfinite(double value);
 
 #endif

--- a/src/float_posix.c
+++ b/src/float_posix.c
@@ -4,4 +4,4 @@
 
 /* posix.1 or c99 provide isfinite */
 
-int float_isfinite(double value) { return isfinite(value); }
+spdr_internal int float_isfinite(double value) { return isfinite(value); }

--- a/src/float_windows.c
+++ b/src/float_windows.c
@@ -2,4 +2,4 @@
 
 #include "float.h"
 
-extern int float_isfinite(double value) { return _finite(value); }
+spdr_internal int float_isfinite(double value) { return _finite(value); }

--- a/src/inlines.h
+++ b/src/inlines.h
@@ -1,4 +1,5 @@
 #if !defined(SPDR_INLINES_H)
+#define SPDR_INLINES_H
 
 #if __cplusplus
 #define VOID_PTR_CAST(type, void_ptr) (type *)(void_ptr)
@@ -6,5 +7,6 @@
 #define VOID_PTR_CAST(type, void_ptr) void_ptr
 #endif
 
-#define SPDR_INLINES_H
+#define spdr_internal static
+
 #endif

--- a/src/murmur.h
+++ b/src/murmur.h
@@ -20,7 +20,7 @@
 /**
  * rotate left a 32bit integer
  */
-static FORCE_INLINE uint32_t rotl32(uint32_t const x, int8_t const r)
+spdr_internal FORCE_INLINE uint32_t rotl32(uint32_t const x, int8_t const r)
 {
         return (x << r) | (x >> (32 - r));
 }
@@ -29,7 +29,7 @@ static FORCE_INLINE uint32_t rotl32(uint32_t const x, int8_t const r)
  * Block read - if your platform needs to do endian-swapping or can only
  * handle aligned reads, do the conversion here
  */
-static FORCE_INLINE uint32_t
+spdr_internal FORCE_INLINE uint32_t
 private_murmur3_getblock(uint32_t const *p, int const i)
 {
         return p[i];
@@ -38,10 +38,10 @@ private_murmur3_getblock(uint32_t const *p, int const i)
 /**
  * Murmur3 mix
  */
-static FORCE_INLINE void murmur3_bmix32(uint32_t *__restrict__ h1,
-                                        uint32_t *__restrict__ k1,
-                                        uint32_t *__restrict__ c1,
-                                        uint32_t *__restrict__ c2)
+spdr_internal FORCE_INLINE void murmur3_bmix32(uint32_t *__restrict__ h1,
+                                               uint32_t *__restrict__ k1,
+                                               uint32_t *__restrict__ c1,
+                                               uint32_t *__restrict__ c2)
 {
         *c1 = *c1 * 5 + 0x7b7d159c;
         *c2 = *c2 * 5 + 0x6bce6396;
@@ -55,7 +55,8 @@ static FORCE_INLINE void murmur3_bmix32(uint32_t *__restrict__ h1,
         *h1 ^= *k1;
 }
 
-static uint32_t murmurhash3_32(void const *key, int len, uint32_t const seed)
+spdr_internal uint32_t
+murmurhash3_32(void const *key, int len, uint32_t const seed)
 {
         const uint8_t *data = (const uint8_t *)key;
         const int nblocks = len / 4;

--- a/src/spdr-internal.h
+++ b/src/spdr-internal.h
@@ -1,9 +1,10 @@
 #ifndef UU_SPDR_INTERNAL_H
 #define UU_SPDR_INTERNAL_H
 
+#include "inlines.h"
 #include "uu-stdint.h"
 
-extern uint32_t uu_spdr_get_pid();
-extern uint64_t uu_spdr_get_tid();
+spdr_internal uint32_t uu_spdr_get_pid();
+spdr_internal uint64_t uu_spdr_get_tid();
 
 #endif

--- a/src/spdr-thread_posix.c
+++ b/src/spdr-thread_posix.c
@@ -2,4 +2,4 @@
 
 #include <pthread.h>
 
-uint64_t uu_spdr_get_tid() { return (intptr_t)pthread_self(); }
+spdr_internal uint64_t uu_spdr_get_tid() { return (intptr_t)pthread_self(); }

--- a/src/spdr.c
+++ b/src/spdr.c
@@ -351,9 +351,10 @@ extern void spdr_enable_trace(struct SPDR_Context *context, int traceon)
         context->tracing_p = traceon;
 }
 
-int uu_spdr_musttrace(const struct SPDR_Context *context)
+extern int uu_spdr_musttrace(const struct SPDR_Context *context)
 {
-        return context->tracing_p;
+        /*  FEATURE: a null context is treated as a *never tracing* context */
+        return context && context->tracing_p;
 }
 
 extern struct SPDR_Event_Arg uu_spdr_arg_make_int(const char *key, int value)

--- a/src/spdr.c
+++ b/src/spdr.c
@@ -345,6 +345,8 @@ void spdr_set_log_fn(struct SPDR_Context *context,
 
 /**
  * Activates the recording of traces (off by default)
+ *
+ * FEATURE: tracing is activated and deactivated at runtime
  */
 extern void spdr_enable_trace(struct SPDR_Context *context, int traceon)
 {

--- a/src/spdr_windows.c
+++ b/src/spdr_windows.c
@@ -2,6 +2,6 @@
 
 #include <windows.h>
 
-uint32_t uu_spdr_get_pid() { return GetCurrentProcessId(); }
+spdr_internal uint32_t uu_spdr_get_pid() { return GetCurrentProcessId(); }
 
-uint64_t uu_spdr_get_tid() { return GetCurrentThreadId(); }
+spdr_internal uint64_t uu_spdr_get_tid() { return GetCurrentThreadId(); }


### PR DESCRIPTION
- Null context is handled as a never tracing context
- Workaround to avoid problems with C++ One Definition Rule
- Export less symbols to user application